### PR TITLE
fixed disableSystemClock

### DIFF
--- a/src/SparkFun_Alphanumeric_Display.cpp
+++ b/src/SparkFun_Alphanumeric_Display.cpp
@@ -294,7 +294,7 @@ bool HT16K33::disableSystemClock()
 	bool status = true;
 	for (uint8_t i = 0; i < numberOfDisplays; i++)
 	{
-		if (enableSystemClockSingle(i) == false)
+		if (disableSystemClockSingle(i) == false)
 			status = false;
 	}
 	return status;


### PR DESCRIPTION
Bugfix for disableSystemClock.  Function previously called enableSystemClockSingle instead of disableSystemClockSingle.