### PR TITLE
Fix display number for colon and decimal

### DIFF
--- a/src/SparkFun_Alphanumeric_Display.cpp
+++ b/src/SparkFun_Alphanumeric_Display.cpp
@@ -636,7 +636,7 @@ void HT16K33::printChar(uint8_t displayChar, uint8_t digit)
 		characterPosition = displayChar - '!' + 1;
 	}
 
-	uint8_t dispNum = digitPosition / 4;
+	uint8_t dispNum = (digitPosition / 4) + 1;
 
 	// Take care of special characters by turning correct segment on
 	if (characterPosition == 14) // '.'


### PR DESCRIPTION
printChar(':', 0) is used in several places in the code to turn on the
colon and decimal point. However, the printChar() code resolves the
digit index of 0 to display number 0, but display indexes are one-based
so the colon or decimal chars never get displayed. This commit was only
tested with a single display and this library appears to have larger
limitations with handling colon and decimal chars across multiple
displays.

Here's a test case that this commit fixes:

  display.print(" 1:2.3");