### PR TITLE
Correct bitwise OR to logical OR

### DIFF
--- a/src/SparkFun_Alphanumeric_Display.cpp
+++ b/src/SparkFun_Alphanumeric_Display.cpp
@@ -728,7 +728,7 @@ uint16_t HT16K33::getSegmentsToTurnOn(uint8_t charPos)
 size_t HT16K33::write(uint8_t b)
 {
 	// If user wants to print '.' or ':', don't increment the digitPosition!
-	if (b == '.' | b == ':')
+	if (b == '.' || b == ':')
 		printChar(b, 0);
 	else
 	{


### PR DESCRIPTION
Fix a typo where a bitwise OR was used instead of a logical OR in a conditional.