### PR TITLE
printChar() updates displayRAM instead of calling decimal/colonOnSing…

### DIFF
--- a/src/SparkFun_Alphanumeric_Display.cpp
+++ b/src/SparkFun_Alphanumeric_Display.cpp
@@ -640,9 +640,9 @@ void HT16K33::printChar(uint8_t displayChar, uint8_t digit)
 
 	// Take care of special characters by turning correct segment on
 	if (characterPosition == 14) // '.'
-		decimalOnSingle(dispNum+1);
+		displayRAM[(dispNum * 16) + 3] = displayRAM[(dispNum * 16) + 3] | 1;
 	if (characterPosition == 26) // ':'
-		colonOnSingle(dispNum+1);
+		displayRAM[(dispNum * 16) + 1] = displayRAM[(dispNum * 16) + 1] | 1;
 	if (characterPosition == 65532) // unknown character
 		characterPosition = SFE_ALPHANUM_UNKNOWN_CHAR;
 


### PR DESCRIPTION
printChar() updates displayRAM instead of calling decimal/colonOnSingle()

This avoids the flicker which results when decimal/colonOnSingle() call updateDisplay before displayRAM has been fully updated and fixes issue #16 